### PR TITLE
Display color of who input each letter

### DIFF
--- a/app/components/PuzzleCell.tsx
+++ b/app/components/PuzzleCell.tsx
@@ -36,6 +36,14 @@ export default memo(function PuzzleCell({
 
   const isBlackCell = content === '.';
   const cellContent = !isBlackCell && content !== '-' && content;
+  const cellColor = useSelector(({remote}) => {
+    if (!cellContent) {
+      return;
+    }
+
+    const cellOwner = remote.cellOwners?.[index]?.[cellContent];
+    return cellOwner && remote.users[cellOwner].color;
+  })
 
   const handleKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === 'Backspace' || event.key === 'Delete') {
@@ -94,7 +102,7 @@ export default memo(function PuzzleCell({
       }}
     >
       {number && <span className={styles.number}>{number}</span>}
-      <span className={styles.content}>
+      <span className={styles.content} style={{color: cellColor}}>
         {cellContent && cellContent.toLocaleUpperCase()}
         {markup?.unknown_04 && <sup className={styles.superscript}>*</sup>}
       </span>

--- a/app/store/isomorphic/executor.ts
+++ b/app/store/isomorphic/executor.ts
@@ -42,7 +42,7 @@ export const executor: Executor<
         deletedIndex = getPrevIndex(remote.puzzle, local)!;
         execute({ type: 'RETREAT_CURSOR', payload: { userId: command.payload.userId } });
       }
-      dispatchRemote({ type: 'CELL_CHANGED', payload: { index: deletedIndex, value: '-' } });
+      dispatchRemote({ type: 'CELL_CHANGED', payload: { index: deletedIndex, value: '-', userId: command.payload.userId } });
       break;
     }
 
@@ -63,7 +63,7 @@ export const executor: Executor<
 
       dispatchRemote({
         type: 'CELL_CHANGED',
-        payload: { index, value, isPencil: local.isPencil },
+        payload: { index, value, isPencil: local.isPencil, userId },
       });
       execute({ type: 'ADVANCE_CURSOR', payload: { userId } });
       break;

--- a/app/store/remote/puzzle.ts
+++ b/app/store/remote/puzzle.ts
@@ -4,6 +4,9 @@ import { checkPuzzle } from '~/util/checkPuzzle';
 
 export type State = {
   puzzle?: Puzzle;
+  // Mapping from cell index to a map from letter to who first
+  // input that letter
+  cellOwners?: Record<number, Record<string, string | undefined>>;
   autocheck?: boolean;
   isCorrect?: boolean;
 };
@@ -15,7 +18,7 @@ export type Action =
     }
   | {
       type: 'CELL_CHANGED';
-      payload: { index: number; value: string; isPencil?: boolean };
+      payload: { index: number; value: string; userId: string, isPencil?: boolean };
     }
   | {
       type: 'CHECK_PUZZLE';
@@ -55,7 +58,8 @@ export const reducer = (state: State, { type, payload }: Action) => {
       }
       // update the character at the given position
       const nextState = [...state.puzzle.state];
-      nextState[payload.index] = payload.value.slice(0, 1).toUpperCase();
+      const value = payload.value.slice(0, 1).toUpperCase();
+      nextState[payload.index] = value;
 
       // also set markup flag
       const markupGrid = state.puzzle.markupGrid?.slice() ?? [];
@@ -74,7 +78,11 @@ export const reducer = (state: State, { type, payload }: Action) => {
         puzzle = checkPuzzle(puzzle);
       }
 
-      return { ...state, puzzle, isCorrect: isCorrect(puzzle, true) };
+      const cellOwners = state.cellOwners || {};
+      cellOwners[payload.index] = cellOwners[payload.index] || {};
+      cellOwners[payload.index][value] = cellOwners[payload.index][value] || payload.userId;
+
+      return { ...state, puzzle, isCorrect: isCorrect(puzzle, true), cellOwners };
     }
 
     // NOTE: This only sets a markup flag (for now)


### PR DESCRIPTION
Display the cell value in the color of the user who entered it.  There is a little weirdness to consider here in that if User A first enters 'x', then User B enters 'y', and finally User C enters 'x' again we want to still attribute that as User A's entry.  This required an extra dictionary per cell to track all past entries.

<img width="1850" height="1053" alt="image" src="https://github.com/user-attachments/assets/686b0830-2585-4e2c-ad3a-9c5289d89736" />

An open question is whether these colors are too strong.  Should I make them darker or keep as is?
